### PR TITLE
Existence of "Timed Out" Sessions break list_sessions()

### DIFF
--- a/browserbase/__init__.py
+++ b/browserbase/__init__.py
@@ -11,7 +11,7 @@ BrowserType = Literal["chrome", "firefox", "edge", "safari"]
 DeviceType = Literal["desktop", "mobile"]
 OperatingSystem = Literal["windows", "macos", "linux", "ios", "android"]
 SessionStatus = Literal[
-    "NEW", "CREATED", "ERROR", "RUNNING", "REQUEST_RELEASE", "RELEASING", "COMPLETED"
+    "NEW", "CREATED", "ERROR", "RUNNING", "REQUEST_RELEASE", "RELEASING", "COMPLETED", "TIMED_OUT"
 ]
 
 


### PR DESCRIPTION
I've had some BrowserBase sessions enter a "Timed Out" state and the python-sdk doesn't seem to recognize it
<img width="1066" alt="Screenshot 2024-08-13 at 10 00 56 PM" src="https://github.com/user-attachments/assets/076e68cd-7cad-48ba-b1ef-7672aadf9173">

This is the code I used to recreate the error
```python
from browserbase import Browserbase
browserbase = Browserbase()
browserbase.list_sessions()
```
Traceback
```shell
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/benkaufman/repositories/browserstuff/bbyolo/.venv/lib/python3.11/site-packages/browserbase/__init__.py", line 138, in list_sessions
    return [Session(**item) for item in data]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/benkaufman/repositories/browserstuff/bbyolo/.venv/lib/python3.11/site-packages/browserbase/__init__.py", line 138, in <listcomp>
    return [Session(**item) for item in data]
            ^^^^^^^^^^^^^^^
  File "/Users/benkaufman/repositories/browserstuff/bbyolo/.venv/lib/python3.11/site-packages/pydantic/main.py", line 193, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Session
status
  Input should be 'NEW', 'CREATED', 'ERROR', 'RUNNING', 'REQUEST_RELEASE', 'RELEASING' or 'COMPLETED' [type=literal_error, input_value='TIMED_OUT', input_type=str]
    For further information visit https://errors.pydantic.dev/2.8/v/literal_error
```

Most recent timed out session in my account has the id: `54d54ab4-3118-44ac-997f-a1e7264ae504` which I feel comfortable posting here but lmk if I shouldn't post it and I'll take it down.